### PR TITLE
Feature/che

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,0 +1,14 @@
+{
+    "presets": [
+        [
+            "@babel/preset-env",
+            {
+                "targets": {
+                    "node": "current"
+                }
+            }
+        ],
+        "@babel/preset-react",
+        "@babel/preset-typescript"
+    ]
+}

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>switchwon</title>
   </head>
   <body>
     <div id="root"></div>

--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/jest.config.json
+++ b/jest.config.json
@@ -1,0 +1,10 @@
+{
+    "testEnvironment": "jsdom",
+    "moduleNameMapper": {
+        "\\.(css|less|svg)$": "identity-obj-proxy"
+    },
+    "setupFilesAfterEnv": ["<rootDir>/jest-setup.ts"],
+    "transform": {
+        "^.+\\.tsx?$": "ts-jest"
+    }
+}

--- a/jest.config.json
+++ b/jest.config.json
@@ -1,4 +1,7 @@
 {
+    "roots": ["./src"],
+    "testMatch": ["**/__tests__/**/*.+(js|jsx|ts|tsx)", "**/?(*.)+(spec|test).+(js|jsx|ts|tsx)"],
+    "testPathIgnorePatterns": ["/node_modules/"],
     "testEnvironment": "jsdom",
     "moduleNameMapper": {
         "\\.(css|less|svg)$": "identity-obj-proxy"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "prebuild": "npm run test",
+    "test": "jest"
   },
   "dependencies": {
     "@tanstack/react-query": "^4.27.0",
@@ -18,6 +20,12 @@
     "react-router-dom": "^6.9.0"
   },
   "devDependencies": {
+    "@babel/preset-env": "^7.20.2",
+    "@babel/preset-react": "^7.18.6",
+    "@babel/preset-typescript": "^7.21.0",
+    "@testing-library/jest-dom": "^5.16.5",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.4.3",
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.9",
     "@typescript-eslint/eslint-plugin": "^5.54.1",
@@ -32,10 +40,14 @@
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "husky": "^8.0.3",
+    "identity-obj-proxy": "^3.0.0",
+    "jest": "^29.5.0",
+    "jest-environment-jsdom": "^29.5.0",
     "lint-staged": "^13.1.2",
     "postcss": "^8.4.21",
     "prettier": "^2.8.4",
     "tailwindcss": "^3.2.7",
+    "ts-jest": "^29.0.5",
     "typescript": "^4.9.3",
     "vite": "^4.0.0",
     "vite-tsconfig-paths": "^4.0.5"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-react": "^7.18.6",
     "@babel/preset-typescript": "^7.21.0",
+    "@testing-library/dom": "^9.0.1",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",

--- a/package.json
+++ b/package.json
@@ -15,11 +15,14 @@
     "axios": "^1.3.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.9.0"
+    "react-icons": "^4.8.0",
+    "react-router-dom": "^6.9.0",
+    "styled-components": "^5.3.9"
   },
   "devDependencies": {
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.9",
+    "@types/styled-components": "^5.1.26",
     "@typescript-eslint/eslint-plugin": "^5.54.1",
     "@typescript-eslint/parser": "^5.54.1",
     "@vitejs/plugin-react-swc": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -15,17 +15,15 @@
     "axios": "^1.3.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-icons": "^4.8.0",
-    "react-router-dom": "^6.9.0",
-    "styled-components": "^5.3.9"
+    "react-router-dom": "^6.9.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.9",
-    "@types/styled-components": "^5.1.26",
     "@typescript-eslint/eslint-plugin": "^5.54.1",
     "@typescript-eslint/parser": "^5.54.1",
     "@vitejs/plugin-react-swc": "^3.0.0",
+    "autoprefixer": "^10.4.14",
     "eslint": "^8.35.0",
     "eslint-config-prettier": "^8.7.0",
     "eslint-import-resolver-typescript": "^3.5.3",
@@ -35,7 +33,9 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "husky": "^8.0.3",
     "lint-staged": "^13.1.2",
+    "postcss": "^8.4.21",
     "prettier": "^2.8.4",
+    "tailwindcss": "^3.2.7",
     "typescript": "^4.9.3",
     "vite": "^4.0.0",
     "vite-tsconfig-paths": "^4.0.5"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview",
     "prepare": "husky install",
     "prebuild": "npm run test",
-    "test": "jest"
+    "test": "jest --watch"
   },
   "dependencies": {
     "@tanstack/react-query": "^4.27.0",

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from "@testing-library/react";
+import App from "./App";
+
+describe("App", () => {
+  it("renders header", () => {
+    render(<App />);
+    const header = screen.getByText(/switch/i);
+    expect(header).toBeInTheDocument();
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,13 @@
+import { Outlet } from "react-router-dom";
+import Header from "./components/common/Header";
+
 const App = () => {
-  return <div>App</div>;
+  return (
+    <>
+      <Header />
+      <Outlet />
+    </>
+  );
 };
+
 export default App;

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,1 +1,26 @@
-export {};
+import { createBrowserRouter, Navigate } from "react-router-dom";
+import App from "./App";
+import OrderList from "./pages/OrderList";
+
+const Router = createBrowserRouter([
+  {
+    path: "/",
+    element: <App />,
+    children: [
+      {
+        path: "",
+        element: <Navigate to="/orderlist" replace />,
+      },
+      {
+        path: "/orderlist",
+        element: <OrderList />,
+      },
+      {
+        path: "*",
+        element: <Navigate to="/orderlist" replace />,
+      },
+    ],
+  },
+]);
+
+export default Router;

--- a/src/__test__/util.tsx
+++ b/src/__test__/util.tsx
@@ -6,9 +6,16 @@ export function renderWithRouterMatch(
   ui: JSX.Element,
   { path = "/", route = "/" } = {},
 ) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
   return {
     ...render(
-      <QueryClientProvider client={new QueryClient()}>
+      <QueryClientProvider client={queryClient}>
         <MemoryRouter initialEntries={[route]}>
           <Routes>
             <Route path={path} element={ui} />

--- a/src/__test__/util.tsx
+++ b/src/__test__/util.tsx
@@ -1,0 +1,20 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+
+export function renderWithRouterMatch(
+  ui: JSX.Element,
+  { path = "/", route = "/" } = {},
+) {
+  return {
+    ...render(
+      <QueryClientProvider client={new QueryClient()}>
+        <MemoryRouter initialEntries={[route]}>
+          <Routes>
+            <Route path={path} element={ui} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    ),
+  };
+}

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,18 +1,21 @@
 import type { QueryFunctionContext } from "@tanstack/react-query";
 import type { AxiosResponse } from "axios";
-import type { dataResponse } from "../types";
+import type { IDataResponse, IResponse } from "../types";
+import { getEndNumber, getStartNumber } from "../utils/pageUtil";
 import axiosInstance from "./instance";
 
 export const getData = async ({
   queryKey,
-}: QueryFunctionContext): Promise<dataResponse[]> => {
-  const [_, status, customer_name] = queryKey;
+}: QueryFunctionContext): Promise<IResponse> => {
+  const [_, status, customer_name, page] = queryKey;
 
   const today = "2023-03-08";
 
-  const { data }: AxiosResponse<dataResponse[]> = await axiosInstance.get("");
+  const { data }: AxiosResponse<IDataResponse[]> = await axiosInstance.get("");
 
-  return data.filter((item) => {
+  const startPageNumber = getStartNumber(typeof page === "string" ? page : "1");
+
+  const filterData = data.filter((item) => {
     return (
       item.transaction_time.split(" ")[0] === today &&
       (status ? item.status + "" == status : true) &&
@@ -21,4 +24,9 @@ export const getData = async ({
         : true)
     );
   });
+
+  return {
+    data: filterData.slice(startPageNumber, getEndNumber(startPageNumber)),
+    total: filterData.length,
+  };
 };

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -7,7 +7,7 @@ import axiosInstance from "./instance";
 export const getData = async ({
   queryKey,
 }: QueryFunctionContext): Promise<IResponse> => {
-  const [_, status, customer_name, page] = queryKey;
+  const [_, status, customer_name, page, sortKey, sortDir] = queryKey;
 
   const today = "2023-03-08";
 
@@ -24,6 +24,18 @@ export const getData = async ({
         : true)
     );
   });
+
+  if (typeof sortKey === "string") {
+    filterData.sort((a: Record<string, any>, b: Record<string, any>) => {
+      if (a[sortKey] < b[sortKey]) {
+        return sortDir && sortDir === "desc" ? 1 : -1;
+      }
+      if (a[sortKey] > b[sortKey]) {
+        return sortDir && sortDir === "desc" ? -1 : 1;
+      }
+      return 0;
+    });
+  }
 
   return {
     data: filterData.slice(startPageNumber, getEndNumber(startPageNumber)),

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,9 +1,24 @@
-import type { AxiosRequestConfig } from "axios";
-import axios from "axios";
+import type { QueryFunctionContext } from "@tanstack/react-query";
+import type { AxiosResponse } from "axios";
+import type { dataResponse } from "../types";
+import axiosInstance from "./instance";
 
-const config: AxiosRequestConfig = {
-  baseURL: "/mock/data.json",
+export const getData = async ({
+  queryKey,
+}: QueryFunctionContext): Promise<dataResponse[]> => {
+  const [_, status, customer_name] = queryKey;
+
+  const today = "2023-03-08";
+
+  const { data }: AxiosResponse<dataResponse[]> = await axiosInstance.get("");
+
+  return data.filter((item) => {
+    return (
+      item.transaction_time.split(" ")[0] === today &&
+      (status ? item.status + "" == status : true) &&
+      (typeof customer_name == "string"
+        ? item.customer_name.includes(customer_name)
+        : true)
+    );
+  });
 };
-const client = axios.create(config);
-
-export default client;

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -1,0 +1,9 @@
+import type { AxiosRequestConfig } from "axios";
+import axios from "axios";
+
+const config: AxiosRequestConfig = {
+  baseURL: "/mock/data.json",
+};
+const axiosInstance = axios.create(config);
+
+export default axiosInstance;

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,44 +1,15 @@
-import styled from "styled-components";
-
-const Positioner = styled.div`
-  width: 100%;
-`;
-
-const WhiteBackground = styled.div`
-  background: white;
-  display: flex;
-  height: auto;
-`;
-
-const HeaderContents = styled.div`
-  padding: 15px;
-  height: 55px;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-`;
-
-const GradientBorder = styled.div`
-  height: 3px;
-  background: linear-gradient(to right, Orange, Orange, yellow);
-`;
-
-const YellowSpan = styled.span`
-  color: #ff5500;
-`;
-
 const Header = () => {
   return (
-    <Positioner>
-      <WhiteBackground>
-        <HeaderContents>
-          <h1>
-            switch<YellowSpan>won</YellowSpan>
+    <div>
+      <div className="flex">
+        <div className="flex flex-row p-6 items-center">
+          <h1 className="text-3xl font-bold">
+            switch<span className="text-orange-500">won</span>
           </h1>
-        </HeaderContents>
-      </WhiteBackground>
-      <GradientBorder />
-    </Positioner>
+        </div>
+      </div>
+      <div className="h-1 bg-gradient-to-r from-orange-500 to-yellow-500" />
+    </div>
   );
 };
 

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,0 +1,45 @@
+import styled from "styled-components";
+
+const Positioner = styled.div`
+  width: 100%;
+`;
+
+const WhiteBackground = styled.div`
+  background: white;
+  display: flex;
+  height: auto;
+`;
+
+const HeaderContents = styled.div`
+  padding: 15px;
+  height: 55px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`;
+
+const GradientBorder = styled.div`
+  height: 3px;
+  background: linear-gradient(to right, Orange, Orange, yellow);
+`;
+
+const YellowSpan = styled.span`
+  color: #ff5500;
+`;
+
+const Header = () => {
+  return (
+    <Positioner>
+      <WhiteBackground>
+        <HeaderContents>
+          <h1>
+            switch<YellowSpan>won</YellowSpan>
+          </h1>
+        </HeaderContents>
+      </WhiteBackground>
+      <GradientBorder />
+    </Positioner>
+  );
+};
+
+export default Header;

--- a/src/components/orderlist/OrderFilters.test.tsx
+++ b/src/components/orderlist/OrderFilters.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { IOrderFiltersProps } from "./OrderFilters";
+import OrderFilters from "./OrderFilters";
+
+function renderOrderFilters(props?: Partial<IOrderFiltersProps>) {
+  const status = "";
+  const customer_name = "";
+  const updateStatus = jest.fn();
+  const updateCustomerName = jest.fn();
+
+  render(
+    <OrderFilters
+      status={status}
+      customer_name={customer_name}
+      updateStatus={updateStatus}
+      updateCustomerName={updateCustomerName}
+      {...props}
+    />,
+  );
+
+  const orderStatusText = screen.getByText(/주문처리상태 :/i);
+
+  const select = screen.getByTestId("test-select");
+  const input = screen.getByTestId("test-input");
+
+  function changeSelect(val: string) {
+    fireEvent.change(select, { target: { value: val } });
+  }
+
+  function changeInput(name: string) {
+    fireEvent.change(input, { target: { value: name } });
+  }
+
+  return {
+    updateStatus,
+    updateCustomerName,
+    orderStatusText,
+    select,
+    input,
+    changeSelect,
+    changeInput,
+  };
+}
+
+describe("OrderFilters", () => {
+  it("OrderList renders", () => {
+    const { orderStatusText, select, input } = renderOrderFilters();
+
+    expect(orderStatusText).toBeInTheDocument();
+    expect(select).toBeInTheDocument();
+    expect(input).toBeInTheDocument();
+  });
+
+  it("status change event", () => {
+    const { updateStatus, changeSelect } = renderOrderFilters();
+
+    changeSelect("true");
+    expect(updateStatus).toHaveBeenCalledTimes(1);
+    expect(updateStatus).toHaveBeenCalledWith("true");
+
+    changeSelect("false");
+    expect(updateStatus).toHaveBeenCalledTimes(2);
+    expect(updateStatus).toHaveBeenCalledWith("false");
+
+    changeSelect("");
+    expect(updateStatus).toHaveBeenCalledTimes(3);
+    expect(updateStatus).toHaveBeenCalledWith("");
+  });
+
+  it("customer name change event", () => {
+    const { updateCustomerName, changeInput } = renderOrderFilters();
+
+    changeInput("customer name");
+    expect(updateCustomerName).toHaveBeenCalledTimes(1);
+    expect(updateCustomerName).toHaveBeenCalledWith("customer name");
+  });
+});

--- a/src/components/orderlist/OrderFilters.tsx
+++ b/src/components/orderlist/OrderFilters.tsx
@@ -1,3 +1,5 @@
+import SearchIcon from "./SearchIcon";
+
 const OrderFilters = ({
   status,
   customer_name,
@@ -31,20 +33,7 @@ const OrderFilters = ({
       </div>
       <div className="relative flex items-center mt-4 md:mt-0">
         <span className="absolute">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth="1.5"
-            stroke="currentColor"
-            className="w-5 h-5 mx-3 text-gray-400 dark:text-gray-600"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
-            />
-          </svg>
+          <SearchIcon />
         </span>
         <input
           onChange={handleChangeInput}

--- a/src/components/orderlist/OrderFilters.tsx
+++ b/src/components/orderlist/OrderFilters.tsx
@@ -1,0 +1,33 @@
+import { useRef } from "react";
+
+const OrderFilters = ({
+  updateStatus,
+  updateCustomerName,
+}: {
+  updateStatus: (value: string) => void;
+  updateCustomerName: (value: string) => void;
+}) => {
+  const custonmerNameRef = useRef<HTMLInputElement>(null);
+
+  const handleChangeSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    updateStatus(e.target.value);
+  };
+  const handleClickButton = () => {
+    updateCustomerName(
+      custonmerNameRef.current?.value ? custonmerNameRef.current?.value : "",
+    );
+  };
+  return (
+    <div>
+      고객이름 : <input ref={custonmerNameRef} />
+      <button onClick={handleClickButton}>검색</button>
+      <select className="w150" onChange={handleChangeSelect}>
+        <option value=""></option>
+        <option value="true">완료</option>
+        <option value="false">미완료</option>
+      </select>
+    </div>
+  );
+};
+
+export default OrderFilters;

--- a/src/components/orderlist/OrderFilters.tsx
+++ b/src/components/orderlist/OrderFilters.tsx
@@ -1,27 +1,32 @@
-import { useRef } from "react";
-
 const OrderFilters = ({
+  status,
+  customer_name,
   updateStatus,
   updateCustomerName,
 }: {
+  status: string | null;
+  customer_name: string | null;
   updateStatus: (value: string) => void;
   updateCustomerName: (value: string) => void;
 }) => {
-  const custonmerNameRef = useRef<HTMLInputElement>(null);
-
   const handleChangeSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
     updateStatus(e.target.value);
   };
-  const handleClickButton = () => {
-    updateCustomerName(
-      custonmerNameRef.current?.value ? custonmerNameRef.current?.value : "",
-    );
+  const handleChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    updateCustomerName(e.target.value);
   };
   return (
     <div>
-      고객이름 : <input ref={custonmerNameRef} />
-      <button onClick={handleClickButton}>검색</button>
-      <select className="w150" onChange={handleChangeSelect}>
+      고객이름 :{" "}
+      <input
+        onChange={handleChangeInput}
+        defaultValue={customer_name ? customer_name : ""}
+      />
+      <select
+        className="w150"
+        onChange={handleChangeSelect}
+        value={status ? status : ""}
+      >
         <option value=""></option>
         <option value="true">완료</option>
         <option value="false">미완료</option>

--- a/src/components/orderlist/OrderFilters.tsx
+++ b/src/components/orderlist/OrderFilters.tsx
@@ -16,21 +16,43 @@ const OrderFilters = ({
     updateCustomerName(e.target.value);
   };
   return (
-    <div>
-      고객이름 :{" "}
-      <input
-        onChange={handleChangeInput}
-        defaultValue={customer_name ? customer_name : ""}
-      />
-      <select
-        className="w150"
-        onChange={handleChangeSelect}
-        value={status ? status : ""}
-      >
-        <option value=""></option>
-        <option value="true">완료</option>
-        <option value="false">미완료</option>
-      </select>
+    <div className="mt-1 md:flex md:items-center md:justify-end pb-5">
+      <div className="flex mr-2">주문처리상태 : </div>
+      <div className="flex bg-white border rounded-lg mr-10">
+        <select
+          className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+          onChange={handleChangeSelect}
+          value={status ? status : ""}
+        >
+          <option value=""></option>
+          <option value="true">완료</option>
+          <option value="false">미완료</option>
+        </select>
+      </div>
+      <div className="relative flex items-center mt-4 md:mt-0">
+        <span className="absolute">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth="1.5"
+            stroke="currentColor"
+            className="w-5 h-5 mx-3 text-gray-400 dark:text-gray-600"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
+            />
+          </svg>
+        </span>
+        <input
+          onChange={handleChangeInput}
+          placeholder="고객이름"
+          className="block w-full py-1.5 pr-5 text-gray-700 bg-white border border-gray-200 rounded-lg md:w-80 placeholder-gray-400/70 pl-11 rtl:pr-11 rtl:pl-5 dark:bg-gray-900 dark:text-gray-300 dark:border-gray-600 focus:border-blue-400 dark:focus:border-blue-300 focus:ring-blue-300 focus:outline-none focus:ring focus:ring-opacity-40"
+          defaultValue={customer_name ? customer_name : ""}
+        />
+      </div>
     </div>
   );
 };

--- a/src/components/orderlist/OrderFilters.tsx
+++ b/src/components/orderlist/OrderFilters.tsx
@@ -1,16 +1,18 @@
 import SearchIcon from "./SearchIcon";
 
+export interface IOrderFiltersProps {
+  status: string | null;
+  customer_name: string | null;
+  updateStatus: (value: string) => void;
+  updateCustomerName: (value: string) => void;
+}
+
 const OrderFilters = ({
   status,
   customer_name,
   updateStatus,
   updateCustomerName,
-}: {
-  status: string | null;
-  customer_name: string | null;
-  updateStatus: (value: string) => void;
-  updateCustomerName: (value: string) => void;
-}) => {
+}: IOrderFiltersProps) => {
   const handleChangeSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
     updateStatus(e.target.value);
   };
@@ -22,6 +24,7 @@ const OrderFilters = ({
       <div className="flex mr-2">주문처리상태 : </div>
       <div className="flex bg-white border rounded-lg mr-10">
         <select
+          data-testid="test-select"
           className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
           onChange={handleChangeSelect}
           value={status ? status : ""}
@@ -36,6 +39,7 @@ const OrderFilters = ({
           <SearchIcon />
         </span>
         <input
+          data-testid="test-input"
           onChange={handleChangeInput}
           placeholder="고객이름"
           className="block w-full py-1.5 pr-5 text-gray-700 bg-white border border-gray-200 rounded-lg md:w-80 placeholder-gray-400/70 pl-11 rtl:pr-11 rtl:pl-5 dark:bg-gray-900 dark:text-gray-300 dark:border-gray-600 focus:border-blue-400 dark:focus:border-blue-300 focus:ring-blue-300 focus:outline-none focus:ring focus:ring-opacity-40"

--- a/src/components/orderlist/OrderTable.test.tsx
+++ b/src/components/orderlist/OrderTable.test.tsx
@@ -1,0 +1,118 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { IOrderTableProps } from "./OrderTable";
+import OrderTable from "./OrderTable";
+
+function renderOrderTable(props?: Partial<IOrderTableProps>) {
+  const data = [
+    {
+      id: 1,
+      transaction_time: "2023-03-07 17:39:50",
+      status: true,
+      customer_id: 15,
+      customer_name: "Holmes Howard",
+      currency: "$5.61",
+    },
+    {
+      id: 2,
+      transaction_time: "2023-03-08 06:59:37",
+      status: true,
+      customer_id: 16,
+      customer_name: "Cynthia Terrell",
+      currency: "$10.99",
+    },
+    {
+      id: 3,
+      transaction_time: "2023-03-08 00:41:58",
+      status: true,
+      customer_id: 17,
+      customer_name: "Ann Barron",
+      currency: "$37.87",
+    },
+  ];
+  const sortKey = "";
+  const sortDir = "";
+  const setSortConfig = jest.fn();
+
+  render(
+    <OrderTable
+      data={data}
+      sortKey={sortKey}
+      sortDir={sortDir}
+      setSortConfig={setSortConfig}
+      {...props}
+    />,
+  );
+
+  const th_id = screen.getByText(/주문번호/i);
+  const th_transaction_time = screen.getByText(/거래일/i);
+  const th_status = screen.getByText(/주문처리상태/i);
+  const th_customer_id = screen.getByText(/고객번호/i);
+  const th_customer_name = screen.getByText(/고객이름/i);
+  const th_currency = screen.getByText(/가격/i);
+
+  const id_th = screen.getByTestId("test-id-th");
+  const transaction_time_th = screen.getByTestId("test-transaction-time-th");
+
+  const tbodyTrElement = screen
+    .getByRole("table")
+    .querySelector("tbody")
+    ?.querySelectorAll("tr");
+
+  function clickIdTh() {
+    fireEvent.click(id_th);
+  }
+
+  function clickIdTransactionTimeTh() {
+    fireEvent.click(transaction_time_th);
+  }
+
+  return {
+    setSortConfig,
+    th_id,
+    th_transaction_time,
+    th_status,
+    th_customer_id,
+    th_customer_name,
+    th_currency,
+    tbodyTrElement,
+    id_th,
+    transaction_time_th,
+    clickIdTh,
+    clickIdTransactionTimeTh,
+  };
+}
+
+describe("OrderTable", () => {
+  it("OrderTable renders", () => {
+    const {
+      th_id,
+      th_transaction_time,
+      th_status,
+      th_customer_id,
+      th_customer_name,
+      th_currency,
+      tbodyTrElement,
+    } = renderOrderTable();
+
+    expect(th_id).toBeInTheDocument();
+    expect(th_transaction_time).toBeInTheDocument();
+    expect(th_status).toBeInTheDocument();
+    expect(th_customer_id).toBeInTheDocument();
+    expect(th_customer_name).toBeInTheDocument();
+    expect(th_currency).toBeInTheDocument();
+    expect(tbodyTrElement?.length).toBe(3);
+  });
+
+  it("tr click event", () => {
+    const { setSortConfig, clickIdTh, clickIdTransactionTimeTh } =
+      renderOrderTable();
+
+    clickIdTh();
+    expect(setSortConfig).toHaveBeenCalledTimes(1);
+    expect(setSortConfig).toHaveBeenCalledWith("id");
+
+    clickIdTransactionTimeTh();
+    expect(setSortConfig).toHaveBeenCalledTimes(2);
+    expect(setSortConfig).toHaveBeenCalledWith("transaction_time");
+  });
+});

--- a/src/components/orderlist/OrderTable.tsx
+++ b/src/components/orderlist/OrderTable.tsx
@@ -1,4 +1,6 @@
 import type { IDataResponse } from "../../types";
+import TableSortAscIcon from "./TableSortAscIcon";
+import TableSortDescIcon from "./TableSortDescIcon";
 
 const OrderTable = ({
   data,
@@ -15,26 +17,51 @@ const OrderTable = ({
     <div className="overflow-hidden border border-gray-200 dark:border-gray-700 md:rounded-lg">
       <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
         <thead className="bg-gray-50 dark:bg-gray-800">
-          <tr className="flex w-full mb-4">
-            <th className="p-4 w-1/4" onClick={() => setSortConfig("id")}>
-              주문번호
-              {sortKey === "id" ? (
-                <span>{sortDir === "asc" ? " ⬇︎" : " ⬆︎"}</span>
-              ) : null}
+          <tr className="flex w-full">
+            <th
+              scope="col"
+              onClick={() => setSortConfig("id")}
+              className="p-4 w-1/4 rtl:text-right text-gray-500 dark:text-gray-400"
+            >
+              <button className="flex items-center gap-x-3 focus:outline-none">
+                <span>주문번호</span>
+                {sortKey === "id" ? (
+                  sortDir === "asc" ? (
+                    <TableSortAscIcon />
+                  ) : (
+                    <TableSortDescIcon />
+                  )
+                ) : null}
+              </button>
             </th>
             <th
-              className="p-4 w-1/4"
+              scope="col"
               onClick={() => setSortConfig("transaction_time")}
+              className="p-4 w-1/4 rtl:text-right text-gray-500 dark:text-gray-400"
             >
-              거래일 & 거래시간
-              {sortKey === "transaction_time" ? (
-                <span>{sortDir === "asc" ? " ⬇︎" : " ⬆︎"}</span>
-              ) : null}
+              <button className="flex items-center gap-x-3 focus:outline-none">
+                <span>거래일 & 거래시간</span>
+                {sortKey === "transaction_time" ? (
+                  sortDir === "asc" ? (
+                    <TableSortAscIcon />
+                  ) : (
+                    <TableSortDescIcon />
+                  )
+                ) : null}
+              </button>
             </th>
-            <th className="p-4 w-1/4">주문처리상태</th>
-            <th className="p-4 w-1/4">고객번호</th>
-            <th className="p-4 w-1/4">고객이름</th>
-            <th className="p-4 w-1/4">가격</th>
+            <th className="p-4 w-1/4 rtl:text-right text-gray-500 dark:text-gray-400">
+              주문처리상태
+            </th>
+            <th className="p-4 w-1/4 rtl:text-right text-gray-500 dark:text-gray-400">
+              고객번호
+            </th>
+            <th className="p-4 w-1/4 rtl:text-right text-gray-500 dark:text-gray-400">
+              고객이름
+            </th>
+            <th className="p-4 w-1/4 rtl:text-right text-gray-500 dark:text-gray-400">
+              가격
+            </th>
           </tr>
         </thead>
         <tbody className="bg-grey-light flex flex-col items-center justify-between overflow-y-scroll w-full h-96">
@@ -43,7 +70,15 @@ const OrderTable = ({
               <td className="p-4 w-1/4">{item.id}</td>
               <td className="p-4 w-1/4 text-center">{item.transaction_time}</td>
               <td className="p-4 w-1/4 text-center">
-                {item.status ? "완료" : "미완료"}
+                {item.status ? (
+                  <span className="bg-green-200 text-green-600 py-1 px-3 rounded-full text-xs">
+                    완료
+                  </span>
+                ) : (
+                  <span className="bg-red-200 text-red-600 py-1 px-3 rounded-full text-xs">
+                    미완료
+                  </span>
+                )}
               </td>
               <td className="p-4 w-1/4 text-center">{item.customer_id}</td>
               <td className="p-4 w-1/4 text-center">{item.customer_name}</td>

--- a/src/components/orderlist/OrderTable.tsx
+++ b/src/components/orderlist/OrderTable.tsx
@@ -2,17 +2,19 @@ import type { IDataResponse } from "../../types";
 import TableSortAscIcon from "./TableSortAscIcon";
 import TableSortDescIcon from "./TableSortDescIcon";
 
+export interface IOrderTableProps {
+  data: IDataResponse[];
+  sortKey: string;
+  sortDir: string;
+  setSortConfig: (key: string) => void;
+}
+
 const OrderTable = ({
   data,
   sortKey,
   sortDir,
   setSortConfig,
-}: {
-  data: IDataResponse[];
-  sortKey: string;
-  sortDir: string;
-  setSortConfig: (key: string) => void;
-}) => {
+}: IOrderTableProps) => {
   return (
     <div className="overflow-hidden border border-gray-200 dark:border-gray-700 md:rounded-lg">
       <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
@@ -21,6 +23,7 @@ const OrderTable = ({
             <th
               scope="col"
               onClick={() => setSortConfig("id")}
+              data-testid="test-id-th"
               className="p-4 w-1/4 rtl:text-right text-gray-500 dark:text-gray-400"
             >
               <button className="flex items-center gap-x-3 focus:outline-none">
@@ -36,6 +39,7 @@ const OrderTable = ({
             </th>
             <th
               scope="col"
+              data-testid="test-transaction-time-th"
               onClick={() => setSortConfig("transaction_time")}
               className="p-4 w-1/4 rtl:text-right text-gray-500 dark:text-gray-400"
             >

--- a/src/components/orderlist/OrderTable.tsx
+++ b/src/components/orderlist/OrderTable.tsx
@@ -12,37 +12,42 @@ const OrderTable = ({
   setSortConfig: (key: string) => void;
 }) => {
   return (
-    <div>
-      <table>
-        <thead>
-          <tr>
-            <th onClick={() => setSortConfig("id")}>
+    <div className="overflow-hidden border border-gray-200 dark:border-gray-700 md:rounded-lg">
+      <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+        <thead className="bg-gray-50 dark:bg-gray-800">
+          <tr className="flex w-full mb-4">
+            <th className="p-4 w-1/4" onClick={() => setSortConfig("id")}>
               주문번호
               {sortKey === "id" ? (
                 <span>{sortDir === "asc" ? " ⬇︎" : " ⬆︎"}</span>
               ) : null}
             </th>
-            <th onClick={() => setSortConfig("transaction_time")}>
+            <th
+              className="p-4 w-1/4"
+              onClick={() => setSortConfig("transaction_time")}
+            >
               거래일 & 거래시간
               {sortKey === "transaction_time" ? (
                 <span>{sortDir === "asc" ? " ⬇︎" : " ⬆︎"}</span>
               ) : null}
             </th>
-            <th>주문처리상태</th>
-            <th>고객번호</th>
-            <th>고객이름</th>
-            <th>가격</th>
+            <th className="p-4 w-1/4">주문처리상태</th>
+            <th className="p-4 w-1/4">고객번호</th>
+            <th className="p-4 w-1/4">고객이름</th>
+            <th className="p-4 w-1/4">가격</th>
           </tr>
         </thead>
-        <tbody>
+        <tbody className="bg-grey-light flex flex-col items-center justify-between overflow-y-scroll w-full h-96">
           {data?.map((item) => (
-            <tr key={item.id}>
-              <td>{item.id}</td>
-              <td>{item.transaction_time}</td>
-              <td>{item.status ? "완료" : "미완료"}</td>
-              <td>{item.customer_id}</td>
-              <td>{item.customer_name}</td>
-              <td>{item.currency}</td>
+            <tr className="flex w-full mb-4" key={item.id}>
+              <td className="p-4 w-1/4">{item.id}</td>
+              <td className="p-4 w-1/4 text-center">{item.transaction_time}</td>
+              <td className="p-4 w-1/4 text-center">
+                {item.status ? "완료" : "미완료"}
+              </td>
+              <td className="p-4 w-1/4 text-center">{item.customer_id}</td>
+              <td className="p-4 w-1/4 text-center">{item.customer_name}</td>
+              <td className="p-4 w-1/4 text-right">{item.currency}</td>
             </tr>
           ))}
         </tbody>

--- a/src/components/orderlist/OrderTable.tsx
+++ b/src/components/orderlist/OrderTable.tsx
@@ -1,6 +1,6 @@
-import type { dataResponse } from "../../types";
+import type { IDataResponse } from "../../types";
 
-const OrderTable = ({ data }: { data: dataResponse[] }) => {
+const OrderTable = ({ data }: { data: IDataResponse[] }) => {
   return (
     <div>
       <table>

--- a/src/components/orderlist/OrderTable.tsx
+++ b/src/components/orderlist/OrderTable.tsx
@@ -1,13 +1,33 @@
 import type { IDataResponse } from "../../types";
 
-const OrderTable = ({ data }: { data: IDataResponse[] }) => {
+const OrderTable = ({
+  data,
+  sortKey,
+  sortDir,
+  setSortConfig,
+}: {
+  data: IDataResponse[];
+  sortKey: string;
+  sortDir: string;
+  setSortConfig: (key: string) => void;
+}) => {
   return (
     <div>
       <table>
         <thead>
           <tr>
-            <th>주문번호</th>
-            <th>거래일 & 거래시간</th>
+            <th onClick={() => setSortConfig("id")}>
+              주문번호
+              {sortKey === "id" ? (
+                <span>{sortDir === "asc" ? " ⬇︎" : " ⬆︎"}</span>
+              ) : null}
+            </th>
+            <th onClick={() => setSortConfig("transaction_time")}>
+              거래일 & 거래시간
+              {sortKey === "transaction_time" ? (
+                <span>{sortDir === "asc" ? " ⬇︎" : " ⬆︎"}</span>
+              ) : null}
+            </th>
             <th>주문처리상태</th>
             <th>고객번호</th>
             <th>고객이름</th>

--- a/src/components/orderlist/OrderTable.tsx
+++ b/src/components/orderlist/OrderTable.tsx
@@ -1,0 +1,34 @@
+import type { dataResponse } from "../../types";
+
+const OrderTable = ({ data }: { data: dataResponse[] }) => {
+  return (
+    <div>
+      <table>
+        <thead>
+          <tr>
+            <th>주문번호</th>
+            <th>거래일 & 거래시간</th>
+            <th>주문처리상태</th>
+            <th>고객번호</th>
+            <th>고객이름</th>
+            <th>가격</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data?.map((item) => (
+            <tr key={item.id}>
+              <td>{item.id}</td>
+              <td>{item.transaction_time}</td>
+              <td>{item.status ? "완료" : "미완료"}</td>
+              <td>{item.customer_id}</td>
+              <td>{item.customer_name}</td>
+              <td>{item.currency}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default OrderTable;

--- a/src/components/orderlist/Pagination.test.tsx
+++ b/src/components/orderlist/Pagination.test.tsx
@@ -1,0 +1,138 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import Pagination from "./Pagination";
+
+function renderPagination(total: number, page: string) {
+  const setPage = jest.fn();
+
+  render(<Pagination total={total} page={page} setPage={setPage} />);
+
+  const first_button = screen.getByTestId("test-first-button");
+  const left_button = screen.getByTestId("test-left-button");
+  const right_button = screen.getByTestId("test-right-button");
+  const last_button = screen.getByTestId("test-last-button");
+
+  return {
+    setPage,
+    first_button,
+    left_button,
+    right_button,
+    last_button,
+  };
+}
+
+describe("Pagination", () => {
+  it("Pagination renders", () => {
+    const { setPage, first_button, left_button, right_button, last_button } =
+      renderPagination(267, "1");
+
+    const number1_button = screen.getByText(/1/i);
+    const number2_button = screen.getByText(/2/i);
+    const number3_button = screen.getByText(/3/i);
+    const number4_button = screen.getByText(/4/i);
+    const number5_button = screen.getByText(/5/i);
+
+    expect(first_button).toBeInTheDocument();
+    expect(left_button).toBeInTheDocument();
+    expect(right_button).toBeInTheDocument();
+    expect(last_button).toBeInTheDocument();
+    expect(number1_button).toBeInTheDocument();
+    expect(number2_button).toBeInTheDocument();
+    expect(number3_button).toBeInTheDocument();
+    expect(number4_button).toBeInTheDocument();
+    expect(number5_button).toBeInTheDocument();
+
+    fireEvent.click(right_button);
+    expect(setPage).toHaveBeenCalledTimes(1);
+    expect(setPage).toHaveBeenCalledWith("1");
+
+    fireEvent.click(number1_button);
+    expect(setPage).toHaveBeenCalledTimes(2);
+    expect(setPage).toHaveBeenCalledWith("0");
+
+    fireEvent.click(number2_button);
+    expect(setPage).toHaveBeenCalledTimes(3);
+    expect(setPage).toHaveBeenCalledWith("1");
+
+    fireEvent.click(number3_button);
+    expect(setPage).toHaveBeenCalledTimes(4);
+    expect(setPage).toHaveBeenCalledWith("2");
+
+    fireEvent.click(number4_button);
+    expect(setPage).toHaveBeenCalledTimes(5);
+    expect(setPage).toHaveBeenCalledWith("3");
+
+    fireEvent.click(number5_button);
+    expect(setPage).toHaveBeenCalledTimes(6);
+    expect(setPage).toHaveBeenCalledWith("4");
+
+    fireEvent.click(last_button);
+    expect(setPage).toHaveBeenCalledTimes(7);
+    expect(setPage).toHaveBeenCalledWith("5");
+  });
+
+  it("click on page 1 of 6", () => {
+    const { setPage, first_button, left_button } = renderPagination(267, "1");
+
+    expect(first_button).toBeDisabled();
+    fireEvent.click(first_button);
+    expect(setPage).toHaveBeenCalledTimes(0);
+
+    expect(left_button).toBeDisabled();
+    fireEvent.click(left_button);
+    expect(setPage).toHaveBeenCalledTimes(0);
+  });
+
+  it("click on page 6 of 6", () => {
+    const { setPage, first_button, left_button, right_button, last_button } =
+      renderPagination(267, "6");
+
+    expect(right_button).toBeDisabled();
+    fireEvent.click(right_button);
+    expect(setPage).toHaveBeenCalledTimes(0);
+
+    expect(last_button).toBeDisabled();
+    fireEvent.click(last_button);
+    expect(setPage).toHaveBeenCalledTimes(0);
+
+    fireEvent.click(first_button);
+    expect(setPage).toHaveBeenCalledTimes(1);
+    expect(setPage).toHaveBeenCalledWith("0");
+
+    fireEvent.click(left_button);
+    expect(setPage).toHaveBeenCalledTimes(2);
+    expect(setPage).toHaveBeenCalledWith("4");
+  });
+
+  it("click on page 1 of 6", () => {
+    const { setPage, first_button, left_button } = renderPagination(267, "1");
+
+    expect(first_button).toBeDisabled();
+    fireEvent.click(first_button);
+    expect(setPage).toHaveBeenCalledTimes(0);
+
+    expect(left_button).toBeDisabled();
+    fireEvent.click(left_button);
+    expect(setPage).toHaveBeenCalledTimes(0);
+  });
+
+  it("click on page 20 of 6", () => {
+    const { setPage, first_button, left_button, right_button, last_button } =
+      renderPagination(267, "20");
+
+    expect(first_button).toBeDisabled();
+    fireEvent.click(first_button);
+    expect(setPage).toHaveBeenCalledTimes(0);
+
+    expect(left_button).toBeDisabled();
+    fireEvent.click(left_button);
+    expect(setPage).toHaveBeenCalledTimes(0);
+
+    fireEvent.click(right_button);
+    expect(setPage).toHaveBeenCalledTimes(1);
+    expect(setPage).toHaveBeenCalledWith("1");
+
+    fireEvent.click(last_button);
+    expect(setPage).toHaveBeenCalledTimes(2);
+    expect(setPage).toHaveBeenCalledWith("0");
+  });
+});

--- a/src/components/orderlist/Pagination.test.tsx
+++ b/src/components/orderlist/Pagination.test.tsx
@@ -135,4 +135,25 @@ describe("Pagination", () => {
     expect(setPage).toHaveBeenCalledTimes(2);
     expect(setPage).toHaveBeenCalledWith("0");
   });
+
+  it("click on page 3 of 3", () => {
+    const { setPage, first_button, left_button, right_button, last_button } =
+      renderPagination(140, "3");
+
+    expect(first_button).toBeDisabled();
+    fireEvent.click(first_button);
+    expect(setPage).toHaveBeenCalledTimes(0);
+
+    fireEvent.click(left_button);
+    expect(setPage).toHaveBeenCalledTimes(1);
+    expect(setPage).toHaveBeenCalledWith("1");
+
+    expect(right_button).toBeDisabled();
+    fireEvent.click(right_button);
+    expect(setPage).toHaveBeenCalledTimes(1);
+
+    expect(last_button).toBeDisabled();
+    fireEvent.click(last_button);
+    expect(setPage).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/components/orderlist/Pagination.tsx
+++ b/src/components/orderlist/Pagination.tsx
@@ -1,4 +1,3 @@
-import styled from "styled-components";
 import { getNumPages } from "../../utils/pageUtil";
 
 const Pagination = ({
@@ -14,67 +13,35 @@ const Pagination = ({
 
   return (
     <>
-      <Nav>
-        <Button
+      <nav className="flex justify-center items-center gap-1 m-4">
+        <button
+          className="border-none rounded-lg p-2 m-0 bg-black text-white text-base hover:bg-orange-600 disabled:bg-gray-400 disabled:cursor-not-allowed "
           onClick={() => setPage(String(Number(page) - 2))}
           disabled={page === "1"}
         >
           &lt;
-        </Button>
+        </button>
         {Array(numPages)
           .fill(0)
           .map((_, i) => (
-            <Button
-              key={i + 1}
+            <button
+              className="border-none rounded-lg p-2 m-0 bg-black text-white text-base hover:bg-orange-600 aria-selected:bg-orange-600 "
+              key={page + (i + 1)}
               onClick={() => setPage(i + "")}
-              aria-current={page == String(i + 1) ? "page" : undefined}
+              aria-selected={page == String(i + 1) ? true : false}
             >
               {i + 1}
-            </Button>
+            </button>
           ))}
-        <Button onClick={() => setPage(page)} disabled={page == numPages + ""}>
+        <button
+          className="border-none rounded-lg p-2 m-0 bg-black text-white text-base hover:bg-orange-600 disabled:bg-gray-400 disabled:cursor-not-allowed"
+          onClick={() => setPage(page)}
+          disabled={page == numPages + ""}
+        >
           &gt;
-        </Button>
-      </Nav>
+        </button>
+      </nav>
     </>
   );
 };
-
-const Nav = styled.nav`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 4px;
-  margin: 16px;
-`;
-
-const Button = styled.button`
-  border: none;
-  border-radius: 8px;
-  padding: 8px;
-  margin: 0;
-  background: black;
-  color: white;
-  font-size: 1rem;
-
-  &:hover {
-    background: tomato;
-    cursor: pointer;
-    transform: translateY(-2px);
-  }
-
-  &[disabled] {
-    background: grey;
-    cursor: revert;
-    transform: revert;
-  }
-
-  &[aria-current] {
-    background: tomato;
-    font-weight: bold;
-    cursor: revert;
-    transform: revert;
-  }
-`;
-
 export default Pagination;

--- a/src/components/orderlist/Pagination.tsx
+++ b/src/components/orderlist/Pagination.tsx
@@ -1,0 +1,80 @@
+import styled from "styled-components";
+import { getNumPages } from "../../utils/pageUtil";
+
+const Pagination = ({
+  total,
+  page,
+  setPage,
+}: {
+  total: number;
+  page: string;
+  setPage: (value: string) => void;
+}) => {
+  const numPages = getNumPages(total);
+
+  return (
+    <>
+      <Nav>
+        <Button
+          onClick={() => setPage(String(Number(page) - 2))}
+          disabled={page === "1"}
+        >
+          &lt;
+        </Button>
+        {Array(numPages)
+          .fill(0)
+          .map((_, i) => (
+            <Button
+              key={i + 1}
+              onClick={() => setPage(i + "")}
+              aria-current={page == String(i + 1) ? "page" : undefined}
+            >
+              {i + 1}
+            </Button>
+          ))}
+        <Button onClick={() => setPage(page)} disabled={page == numPages + ""}>
+          &gt;
+        </Button>
+      </Nav>
+    </>
+  );
+};
+
+const Nav = styled.nav`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 4px;
+  margin: 16px;
+`;
+
+const Button = styled.button`
+  border: none;
+  border-radius: 8px;
+  padding: 8px;
+  margin: 0;
+  background: black;
+  color: white;
+  font-size: 1rem;
+
+  &:hover {
+    background: tomato;
+    cursor: pointer;
+    transform: translateY(-2px);
+  }
+
+  &[disabled] {
+    background: grey;
+    cursor: revert;
+    transform: revert;
+  }
+
+  &[aria-current] {
+    background: tomato;
+    font-weight: bold;
+    cursor: revert;
+    transform: revert;
+  }
+`;
+
+export default Pagination;

--- a/src/components/orderlist/Pagination.tsx
+++ b/src/components/orderlist/Pagination.tsx
@@ -13,34 +13,36 @@ const Pagination = ({
 
   return (
     <>
-      <nav className="flex justify-center items-center gap-1 m-4">
-        <button
-          className="border-none rounded-lg p-2 m-0 bg-black text-white text-base hover:bg-orange-600 disabled:bg-gray-400 disabled:cursor-not-allowed "
-          onClick={() => setPage(String(Number(page) - 2))}
-          disabled={page === "1"}
-        >
-          &lt;
-        </button>
-        {Array(numPages)
-          .fill(0)
-          .map((_, i) => (
-            <button
-              className="border-none rounded-lg p-2 m-0 bg-black text-white text-base hover:bg-orange-600 aria-selected:bg-orange-600 "
-              key={page + (i + 1)}
-              onClick={() => setPage(i + "")}
-              aria-selected={page == String(i + 1) ? true : false}
-            >
-              {i + 1}
-            </button>
-          ))}
-        <button
-          className="border-none rounded-lg p-2 m-0 bg-black text-white text-base hover:bg-orange-600 disabled:bg-gray-400 disabled:cursor-not-allowed"
-          onClick={() => setPage(page)}
-          disabled={page == numPages + ""}
-        >
-          &gt;
-        </button>
-      </nav>
+      {total > 0 ? (
+        <nav className="flex justify-center items-center gap-1 m-4">
+          <button
+            className="border-none rounded-lg p-2 m-0  text-black text-base disabled:cursor-not-allowed "
+            onClick={() => setPage(String(Number(page) - 2))}
+            disabled={page === "1"}
+          >
+            &lt;
+          </button>
+          {Array(numPages)
+            .fill(0)
+            .map((_, i) => (
+              <button
+                className="border-none rounded-3xl p-2 m-0  text-black text-base hover:bg-orange-100 aria-selected:bg-orange-100 "
+                key={page + (i + 1)}
+                onClick={() => setPage(i + "")}
+                aria-selected={page == String(i + 1) ? true : false}
+              >
+                {i + 1}
+              </button>
+            ))}
+          <button
+            className="border-none rounded-lg p-2 m-0  text-black text-base  disabled:cursor-not-allowed"
+            onClick={() => setPage(page)}
+            disabled={page == numPages + ""}
+          >
+            &gt;
+          </button>
+        </nav>
+      ) : null}
     </>
   );
 };

--- a/src/components/orderlist/Pagination.tsx
+++ b/src/components/orderlist/Pagination.tsx
@@ -56,7 +56,10 @@ const Pagination = ({ total, page, setPage }: IPaginationProps) => {
           <button
             className="border-none rounded-lg p-2 m-0  text-black text-base hover:bg-gray-100  disabled:cursor-not-allowed"
             onClick={() => setPage(pagetnum)}
-            disabled={pageArrayIndex === pageArray.length - 1}
+            disabled={
+              pageArrayIndex === pageArray.length - 1 &&
+              pagetnum == String(pages[pages.length - 1] + 1)
+            }
             data-testid="test-right-button"
           >
             &gt;

--- a/src/components/orderlist/Pagination.tsx
+++ b/src/components/orderlist/Pagination.tsx
@@ -1,15 +1,20 @@
-import { getNumPages } from "../../utils/pageUtil";
+import {
+  getNumPages,
+  getPageArrayIndex,
+  sliceArrayByLimit,
+} from "../../utils/pageUtil";
 
-const Pagination = ({
-  total,
-  page,
-  setPage,
-}: {
+export interface IPaginationProps {
   total: number;
   page: string;
   setPage: (value: string) => void;
-}) => {
-  const numPages = getNumPages(total);
+}
+
+const Pagination = ({ total, page, setPage }: IPaginationProps) => {
+  const pageArray = sliceArrayByLimit(getNumPages(total));
+  const pageArrayIndex = getPageArrayIndex(page);
+  const pages =
+    pageArray[pageArrayIndex > pageArray.length - 1 ? 0 : pageArrayIndex];
 
   return (
     <>
@@ -17,29 +22,61 @@ const Pagination = ({
         <nav className="flex justify-center items-center gap-1 m-4">
           <button
             className="border-none rounded-lg p-2 m-0  text-black text-base disabled:cursor-not-allowed "
+            onClick={() =>
+              setPage(
+                String(
+                  pageArray[pageArrayIndex === 0 ? 0 : pageArrayIndex - 1][0],
+                ),
+              )
+            }
+            disabled={pageArrayIndex === 0}
+            data-testid="test-left-button"
+          >
+            &lt;&lt;
+          </button>
+          <button
+            className="border-none rounded-lg p-2 m-0  text-black text-base disabled:cursor-not-allowed "
             onClick={() => setPage(String(Number(page) - 2))}
             disabled={page === "1"}
+            data-testid="test-left-button"
           >
             &lt;
           </button>
-          {Array(numPages)
-            .fill(0)
-            .map((_, i) => (
-              <button
-                className="border-none rounded-3xl p-2 m-0  text-black text-base hover:bg-orange-100 aria-selected:bg-orange-100 "
-                key={page + (i + 1)}
-                onClick={() => setPage(i + "")}
-                aria-selected={page == String(i + 1) ? true : false}
-              >
-                {i + 1}
-              </button>
-            ))}
+          {pages?.map((n) => (
+            <button
+              className="border-none rounded-3xl p-2 m-0  text-black text-base hover:bg-orange-100 aria-selected:bg-orange-100 "
+              key={page + (n + 1)}
+              onClick={() => setPage(n + "")}
+              aria-selected={page == String(n + 1) ? true : false}
+            >
+              {n + 1}
+            </button>
+          ))}
           <button
             className="border-none rounded-lg p-2 m-0  text-black text-base  disabled:cursor-not-allowed"
             onClick={() => setPage(page)}
-            disabled={page == numPages + ""}
+            disabled={pageArrayIndex === pageArray.length - 1}
+            data-testid="test-right-button"
           >
             &gt;
+          </button>
+          <button
+            className="border-none rounded-lg p-2 m-0  text-black text-base  disabled:cursor-not-allowed"
+            onClick={() =>
+              setPage(
+                String(
+                  pageArray[
+                    pageArrayIndex === pageArray.length - 1
+                      ? pageArrayIndex
+                      : pageArrayIndex + 1
+                  ][0],
+                ),
+              )
+            }
+            disabled={pageArrayIndex === pageArray.length - 1}
+            data-testid="test-right-button"
+          >
+            &gt;&gt;
           </button>
         </nav>
       ) : null}

--- a/src/components/orderlist/Pagination.tsx
+++ b/src/components/orderlist/Pagination.tsx
@@ -15,13 +15,14 @@ const Pagination = ({ total, page, setPage }: IPaginationProps) => {
   const pageArrayIndex = getPageArrayIndex(page);
   const pages =
     pageArray[pageArrayIndex > pageArray.length - 1 ? 0 : pageArrayIndex];
+  const pagetnum = pageArrayIndex > pageArray.length - 1 ? "1" : page;
 
   return (
     <>
       {total > 0 ? (
         <nav className="flex justify-center items-center gap-1 m-4">
           <button
-            className="border-none rounded-lg p-2 m-0  text-black text-base disabled:cursor-not-allowed "
+            className="border-none rounded-lg p-2 m-0  text-black text-base hover:bg-gray-100 disabled:cursor-not-allowed "
             onClick={() =>
               setPage(
                 String(
@@ -29,15 +30,15 @@ const Pagination = ({ total, page, setPage }: IPaginationProps) => {
                 ),
               )
             }
-            disabled={pageArrayIndex === 0}
-            data-testid="test-left-button"
+            disabled={pageArrayIndex === 0 || pagetnum == "1"}
+            data-testid="test-first-button"
           >
             &lt;&lt;
           </button>
           <button
-            className="border-none rounded-lg p-2 m-0  text-black text-base disabled:cursor-not-allowed "
-            onClick={() => setPage(String(Number(page) - 2))}
-            disabled={page === "1"}
+            className="border-none rounded-lg p-2 m-0  text-black text-base hover:bg-gray-100 disabled:cursor-not-allowed "
+            onClick={() => setPage(String(Number(pagetnum) - 2))}
+            disabled={pagetnum === "1"}
             data-testid="test-left-button"
           >
             &lt;
@@ -45,28 +46,30 @@ const Pagination = ({ total, page, setPage }: IPaginationProps) => {
           {pages?.map((n) => (
             <button
               className="border-none rounded-3xl p-2 m-0  text-black text-base hover:bg-orange-100 aria-selected:bg-orange-100 "
-              key={page + (n + 1)}
+              key={pagetnum + (n + 1)}
               onClick={() => setPage(n + "")}
-              aria-selected={page == String(n + 1) ? true : false}
+              aria-selected={pagetnum == String(n + 1) ? true : false}
             >
               {n + 1}
             </button>
           ))}
           <button
-            className="border-none rounded-lg p-2 m-0  text-black text-base  disabled:cursor-not-allowed"
-            onClick={() => setPage(page)}
+            className="border-none rounded-lg p-2 m-0  text-black text-base hover:bg-gray-100  disabled:cursor-not-allowed"
+            onClick={() => setPage(pagetnum)}
             disabled={pageArrayIndex === pageArray.length - 1}
             data-testid="test-right-button"
           >
             &gt;
           </button>
           <button
-            className="border-none rounded-lg p-2 m-0  text-black text-base  disabled:cursor-not-allowed"
+            className="border-none rounded-lg p-2 m-0  text-black text-base hover:bg-gray-100 disabled:cursor-not-allowed"
             onClick={() =>
               setPage(
                 String(
                   pageArray[
-                    pageArrayIndex === pageArray.length - 1
+                    pageArrayIndex > pageArray.length - 1
+                      ? 0
+                      : pageArrayIndex === pageArray.length - 1
                       ? pageArrayIndex
                       : pageArrayIndex + 1
                   ][0],
@@ -74,7 +77,7 @@ const Pagination = ({ total, page, setPage }: IPaginationProps) => {
               )
             }
             disabled={pageArrayIndex === pageArray.length - 1}
-            data-testid="test-right-button"
+            data-testid="test-last-button"
           >
             &gt;&gt;
           </button>

--- a/src/components/orderlist/SearchIcon.tsx
+++ b/src/components/orderlist/SearchIcon.tsx
@@ -1,0 +1,20 @@
+const SearchIcon = () => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth="1.5"
+      stroke="currentColor"
+      className="w-5 h-5 mx-3 text-gray-400 dark:text-gray-600"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
+      />
+    </svg>
+  );
+};
+
+export default SearchIcon;

--- a/src/components/orderlist/TableSortAscIcon.tsx
+++ b/src/components/orderlist/TableSortAscIcon.tsx
@@ -1,0 +1,20 @@
+const TableSortAscIcon = () => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth="1.5"
+      stroke="currentColor"
+      className="h-5"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M3 4.5h14.25M3 9h9.75M3 13.5h9.75m4.5-4.5v12m0 0l-3.75-3.75M17.25 21L21 17.25"
+      />
+    </svg>
+  );
+};
+
+export default TableSortAscIcon;

--- a/src/components/orderlist/TableSortDescIcon.tsx
+++ b/src/components/orderlist/TableSortDescIcon.tsx
@@ -1,0 +1,20 @@
+const TableSortDescIcon = () => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth="1.5"
+      stroke="currentColor"
+      className="h-5"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M3 4.5h14.25M3 9h9.75M3 13.5h5.25m5.25-.75L17.25 9m0 0L21 12.75M17.25 9v12"
+      />
+    </svg>
+  );
+};
+
+export default TableSortDescIcon;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,14 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import ReactDOM from "react-dom/client";
-import App from "./App";
+import { RouterProvider } from "react-router-dom";
+import Router from "./Router";
 
 const queryClient = new QueryClient();
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <QueryClientProvider client={queryClient}>
-    <App />
+    <RouterProvider router={Router} />
     <ReactQueryDevtools />
   </QueryClientProvider>,
 );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import ReactDOM from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 import Router from "./Router";
+import "./index.css";
 
 const queryClient = new QueryClient();
 

--- a/src/pages/OrderList.tsx
+++ b/src/pages/OrderList.tsx
@@ -70,26 +70,32 @@ const OrderList = () => {
   };
 
   return (
-    <div>
-      <h2>주문 목록</h2>
-      <OrderFilters
-        status={status}
-        customer_name={customer_name}
-        updateStatus={updateStatus}
-        updateCustomerName={updateCustomerName}
-      />
-      <OrderTable
-        data={data.data}
-        sortKey={sortKey ? sortKey : "id"}
-        sortDir={sortDir ? sortDir : "asc"}
-        setSortConfig={setSortConfig}
-      />
-      <Pagination
-        total={data.total}
-        page={getPageNumber(page)}
-        setPage={setPage}
-      />
-    </div>
+    <section className="container px-4 mx-auto">
+      <div className="flex flex-col mt-6">
+        <div className="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+          <div className="inline-block min-w-full py-2 align-middle md:px-6 lg:px-8">
+            <h2 className="text-2xl font-bold">주문 목록</h2>
+            <OrderFilters
+              status={status}
+              customer_name={customer_name}
+              updateStatus={updateStatus}
+              updateCustomerName={updateCustomerName}
+            />
+            <OrderTable
+              data={data.data}
+              sortKey={sortKey ? sortKey : "id"}
+              sortDir={sortDir ? sortDir : "asc"}
+              setSortConfig={setSortConfig}
+            />
+            <Pagination
+              total={data.total}
+              page={getPageNumber(page)}
+              setPage={setPage}
+            />
+          </div>
+        </div>
+      </div>
+    </section>
   );
 };
 

--- a/src/pages/OrderList.tsx
+++ b/src/pages/OrderList.tsx
@@ -12,10 +12,14 @@ const OrderList = () => {
   const status = searchParams.get("status");
   const customer_name = searchParams.get("customer_name");
   const page = searchParams.get("page");
+
+  const sortKey = searchParams.get("sortKey");
+  const sortDir = searchParams.get("sortDir");
+
   const currentParams = new URLSearchParams(searchParams.toString());
 
   const { data } = useQuery(
-    ["switchwon", status, customer_name, page],
+    ["switchwon", status, customer_name, page, sortKey, sortDir],
     getData,
     {
       refetchOnWindowFocus: false,
@@ -55,6 +59,16 @@ const OrderList = () => {
     setSearchParams(currentParams);
   };
 
+  const setSortConfig = (key: string) => {
+    if (sortKey && sortKey == key) {
+      currentParams.set("sortDir", sortDir === "asc" ? "desc" : "asc");
+    } else {
+      currentParams.set("sortKey", key);
+      currentParams.set("sortDir", "asc");
+    }
+    setSearchParams(currentParams);
+  };
+
   return (
     <div>
       <h2>주문 목록</h2>
@@ -64,7 +78,12 @@ const OrderList = () => {
         updateStatus={updateStatus}
         updateCustomerName={updateCustomerName}
       />
-      <OrderTable data={data.data} />
+      <OrderTable
+        data={data.data}
+        sortKey={sortKey ? sortKey : "id"}
+        sortDir={sortDir ? sortDir : "asc"}
+        setSortConfig={setSortConfig}
+      />
       <Pagination
         total={data.total}
         page={getPageNumber(page)}

--- a/src/pages/OrderList.tsx
+++ b/src/pages/OrderList.tsx
@@ -1,0 +1,9 @@
+const OrderList = () => {
+  return (
+    <div>
+      <h2>주문 목록</h2>
+    </div>
+  );
+};
+
+export default OrderList;

--- a/src/pages/OrderList.tsx
+++ b/src/pages/OrderList.tsx
@@ -1,7 +1,47 @@
+import { useQuery } from "@tanstack/react-query";
+import { useSearchParams } from "react-router-dom";
+import { getData } from "../api/axios";
+import OrderFilters from "../components/orderlist/OrderFilters";
+import OrderTable from "../components/orderlist/OrderTable";
+
 const OrderList = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const status = searchParams.get("status");
+  const customer_name = searchParams.get("customer_name");
+  const currentParams = new URLSearchParams(searchParams.toString());
+
+  const { data } = useQuery(["switchwon", status, customer_name], getData, {
+    refetchInterval: 5000,
+    initialData: [],
+  });
+
+  const updateStatus = (value: string) => {
+    if (value) {
+      currentParams.set("status", value);
+    } else {
+      currentParams.delete("status");
+    }
+    setSearchParams(currentParams);
+  };
+
+  const updateCustomerName = (value: string) => {
+    if (value) {
+      currentParams.set("customer_name", value);
+    } else {
+      currentParams.delete("customer_name");
+    }
+    setSearchParams(currentParams);
+  };
+
   return (
     <div>
       <h2>주문 목록</h2>
+      <OrderFilters
+        updateStatus={updateStatus}
+        updateCustomerName={updateCustomerName}
+      />
+      <OrderTable data={data} />
     </div>
   );
 };

--- a/src/pages/OrderList.tsx
+++ b/src/pages/OrderList.tsx
@@ -3,20 +3,32 @@ import { useSearchParams } from "react-router-dom";
 import { getData } from "../api/axios";
 import OrderFilters from "../components/orderlist/OrderFilters";
 import OrderTable from "../components/orderlist/OrderTable";
+import Pagination from "../components/orderlist/Pagination";
+import { getPageNumber } from "../utils/pageUtil";
 
 const OrderList = () => {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const status = searchParams.get("status");
   const customer_name = searchParams.get("customer_name");
+  const page = searchParams.get("page");
   const currentParams = new URLSearchParams(searchParams.toString());
 
-  const { data } = useQuery(["switchwon", status, customer_name], getData, {
-    refetchInterval: 5000,
-    initialData: [],
-  });
+  const { data } = useQuery(
+    ["switchwon", status, customer_name, page],
+    getData,
+    {
+      refetchOnWindowFocus: false,
+      refetchInterval: 5000,
+      initialData: {
+        data: [],
+        total: 0,
+      },
+    },
+  );
 
   const updateStatus = (value: string) => {
+    currentParams.set("page", "1");
     if (value) {
       currentParams.set("status", value);
     } else {
@@ -26,6 +38,7 @@ const OrderList = () => {
   };
 
   const updateCustomerName = (value: string) => {
+    currentParams.set("page", "1");
     if (value) {
       currentParams.set("customer_name", value);
     } else {
@@ -34,14 +47,29 @@ const OrderList = () => {
     setSearchParams(currentParams);
   };
 
+  const setPage = (value: string) => {
+    currentParams.set(
+      "page",
+      (isNaN(Number(value)) ? 1 : parseInt(value) + 1) + "",
+    );
+    setSearchParams(currentParams);
+  };
+
   return (
     <div>
       <h2>주문 목록</h2>
       <OrderFilters
+        status={status}
+        customer_name={customer_name}
         updateStatus={updateStatus}
         updateCustomerName={updateCustomerName}
       />
-      <OrderTable data={data} />
+      <OrderTable data={data.data} />
+      <Pagination
+        total={data.total}
+        page={getPageNumber(page)}
+        setPage={setPage}
+      />
     </div>
   );
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,8 +1,13 @@
-export interface dataResponse {
+export interface IDataResponse {
   id: number;
   transaction_time: string;
   status: boolean;
   customer_id: number;
   customer_name: string;
   currency: string;
+}
+
+export interface IResponse {
+  data: IDataResponse[];
+  total: number;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,8 @@
+export interface dataResponse {
+  id: number;
+  transaction_time: string;
+  status: boolean;
+  customer_id: number;
+  customer_name: string;
+  currency: string;
+}

--- a/src/utils/pageUtil.ts
+++ b/src/utils/pageUtil.ts
@@ -1,0 +1,17 @@
+export const pageLimit = 50;
+
+export const getNumPages = (total: number) => {
+  return Math.ceil(total / pageLimit);
+};
+
+export const getPageNumber = (page: string | null): string => {
+  return page && !isNaN(Number(page)) ? page : "1";
+};
+
+export const getStartNumber = (page: string | null) => {
+  return (Number(getPageNumber(page)) - 1) * pageLimit;
+};
+
+export const getEndNumber = (start: number) => {
+  return start + pageLimit;
+};

--- a/src/utils/pageUtil.ts
+++ b/src/utils/pageUtil.ts
@@ -1,4 +1,5 @@
 export const pageLimit = 50;
+export const limit = 5;
 
 export const getNumPages = (total: number) => {
   return Math.ceil(total / pageLimit);
@@ -14,4 +15,17 @@ export const getStartNumber = (page: string | null) => {
 
 export const getEndNumber = (start: number) => {
   return start + pageLimit;
+};
+
+export const sliceArrayByLimit = (totalPage: number) => {
+  const totalPageArray = Array(totalPage)
+    .fill(0)
+    .map((_, i) => i);
+  return Array(Math.ceil(totalPage / limit))
+    .fill(0)
+    .map(() => totalPageArray.splice(0, limit));
+};
+
+export const getPageArrayIndex = (page: string) => {
+  return Math.floor(Number(page) / 5) - (Number(page) % 5 === 0 ? 1 : 0);
 };

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
- mock 데이터를 사용하지 않을때는 페이지가 변할때 마다 서버에서 데이터를 들고올 것이라고 예상하였음
- 왜냐하면 500건을 한꺼번에 들고오는것보다 50건을 들고오는게 서버 부하가 적을것 (select query 시)
- 따라서 api에서 원래는 서버 요청시 /orderlist?page=1&status=true&sortKey=id&sortDir=asc 이런 query string을 바로 전달할것으로 예상
- 실제 데이터로 변경할시 수정이 쉽도록 api에서 필터링, 정렬, 페이지네이션 구현

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/80516736/226880429-375cd69d-37cd-4870-aac5-e2e070345516.gif)
